### PR TITLE
Refactor to load most of plugin after `plugins_loaded`

### DIFF
--- a/includes/class-sensei-share-your-grade-dependency-checker.php
+++ b/includes/class-sensei-share-your-grade-dependency-checker.php
@@ -88,7 +88,7 @@ class Sensei_Share_Your_Grade_Dependency_Checker {
 		}
 
 		// translators: %1$s is version of PHP that this plugin requires; %2$s is the version of PHP WordPress is running on.
-		$message = sprintf( __( '<strong>Sensei Share Your Grade</strong> requires PHP version %1$s but you are running %2$s.', 'sensei-share-your-grade' ), self::MINIMUM_PHP_VERSION, phpversion() );
+		$message = sprintf( __( '<strong>Sensei Share Your Grade</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-share-your-grade' ), self::MINIMUM_PHP_VERSION, phpversion() );
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );
 		$php_update_url = 'https://wordpress.org/support/update-php/';

--- a/includes/class-sensei-share-your-grade-dependency-checker.php
+++ b/includes/class-sensei-share-your-grade-dependency-checker.php
@@ -13,39 +13,29 @@ class Sensei_Share_Your_Grade_Dependency_Checker {
 	const MINIMUM_SENSEI_VERSION = '1.11.0';
 
 	/**
-	 * The list of active plugins.
-	 *
-	 * @var array
-	 */
-	private static $active_plugins;
-
-	/**
-	 * Get active plugins.
-	 *
-	 * @return string[]
-	 */
-	private static function get_active_plugins() {
-		if ( ! isset( self::$active_plugins ) ) {
-			self::$active_plugins = (array) get_option( 'active_plugins', array() );
-
-			if ( is_multisite() ) {
-				self::$active_plugins = array_merge( self::$active_plugins, get_site_option( 'active_sitewide_plugins', array() ) );
-			}
-		}
-		return self::$active_plugins;
-	}
-
-	/**
-	 * Checks if all dependencies are met.
+	 * Checks if all system dependencies are met.
 	 *
 	 * @return bool
 	 */
-	public static function are_dependencies_met() {
+	public static function are_system_dependencies_met() {
 		$are_met = true;
 		if ( ! self::check_php() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_php_notice' ) );
 			$are_met = false;
 		}
+		if ( ! $are_met ) {
+			add_action( 'admin_init', array( __CLASS__, 'deactivate_self' ) );
+		}
+		return $are_met;
+	}
+
+	/**
+	 * Checks if all plugin dependencies are met.
+	 *
+	 * @return bool
+	 */
+	public static function are_plugin_dependencies_met() {
+		$are_met = true;
 		if ( ! self::check_sensei() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_sensei_notice' ) );
 			$are_met = false;
@@ -63,28 +53,19 @@ class Sensei_Share_Your_Grade_Dependency_Checker {
 	}
 
 	/**
+	 * Deactivate self.
+	 */
+	public static function deactivate_self() {
+		deactivate_plugins( SENSEI_SHARE_YOUR_GRADE_PLUGIN_BASENAME );
+	}
+
+	/**
 	 * Checks for our Sensei dependency.
 	 *
 	 * @return bool
 	 */
 	private static function check_sensei() {
-		$active_plugins = self::get_active_plugins();
-
-		$search_sensei = array(
-			'sensei/sensei.php',                     // Sensei 2.x from WordPress.org.
-			'sensei/woothemes-sensei.php',           // Sensei 1.x or Sensei 2.x Compatibility Plugin.
-			'woothemes-sensei/woothemes-sensei.php', // Sensei 1.x or Sensei 2.x Compatibility Plugin.
-		);
-
-		$found_sensei = false;
-		foreach ( $search_sensei as $basename ) {
-			if ( in_array( $basename, $active_plugins, true ) || array_key_exists( $basename, $active_plugins ) ) {
-				$found_sensei = true;
-				break;
-			}
-		}
-
-		if ( ! $found_sensei && ! class_exists( 'Sensei_Main' ) ) {
+		if ( ! class_exists( 'Sensei_Main' ) ) {
 			return false;
 		}
 

--- a/includes/class-sensei-share-your-grade.php
+++ b/includes/class-sensei-share-your-grade.php
@@ -103,48 +103,67 @@ final class Sensei_Share_Your_Grade {
 	 * @since   1.0.0
 	 * @return  void
 	 */
-	public function __construct ( $file, $version = '1.0.0' ) {
+	public function __construct () {
 		$this->_token = 'sensei-share-your-grade';
-		$this->_version = $version;
+		$this->_version = SENSEI_SHARE_YOUR_GRADE_VERSION;
 
-		$this->file = $file;
-		$this->dir = dirname( $this->file );
-		$this->assets_dir = trailingslashit( $this->dir ) . 'assets';
-		$this->assets_url = esc_url( trailingslashit( plugins_url( '/assets/', $this->file ) ) );
+		$this->assets_dir = trailingslashit( dirname( SENSEI_SHARE_YOUR_GRADE_PLUGIN_FILE ) ) . 'assets';
+		$this->assets_url = esc_url( trailingslashit( plugins_url( '/assets/', SENSEI_SHARE_YOUR_GRADE_PLUGIN_FILE ) ) );
 
 		$this->_has_output_fb_sdk = false;
 		$this->_has_googleplus_button = false;
 
-		register_activation_hook( $this->file, array( $this, 'install' ) );
+		register_activation_hook( SENSEI_SHARE_YOUR_GRADE_PLUGIN_FILE, array( $this, 'install' ) );
 
 		$this->load_plugin_textdomain();
-		add_action( 'init', array( $this, 'load_localisation' ), 0 );
-
-		// Set up the data we will need for our output.
-		add_action( 'sensei_course_results_content_inside_after', array( $this, 'setup_course_data_before_output' ), 20 );
-		// TODO - change to use more appropriate hooks when available.
-		add_action( 'sensei_lesson_single_meta', array( $this, 'setup_lesson_data_before_output' ), 20 );
-		add_action( 'sensei_quiz_back_link', array( $this, 'setup_lesson_data_before_output' ), 4 );
-
-		// Display a message when viewing course results.
-		add_action( 'sensei_course_results_content_inside_after', array( $this, 'output_sharing_message' ), 30 );
-		// TODO - change to use more appropriate hooks when available.
-		add_action( 'sensei_lesson_single_meta', array( $this, 'output_sharing_message' ), 30 );
-		add_action( 'sensei_quiz_back_link', array( $this, 'output_sharing_message' ), 5 );
-
-		// Display sharing buttons when viewing course results.
-		add_action( 'sensei_course_results_content_inside_after', array( $this, 'output_sharing_buttons' ), 40 );
-		// TODO - change to use more appropriate hooks when available.
-		add_action( 'sensei_lesson_single_meta', array( $this, 'output_sharing_buttons' ), 30 );
-		add_action( 'sensei_quiz_back_link', array( $this, 'output_sharing_buttons' ), 5 );
-
-		// Conditionally output the JavaScript for the Google Plus button, if it is present.
-		add_action( 'wp_footer', array( $this, 'maybe_render_googleplus_js' ) );
-
-		// Load frontend CSS
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ), 10 );
 
 	} // End __construct()
+
+	/**
+	 * Set up all actions and filters.
+	 */
+	public static function init() {
+		$instance = self::instance();
+		add_action( 'init', array( $instance, 'load_localisation' ), 0 );
+
+		if ( ! Sensei_Share_Your_Grade_Dependency_Checker::are_plugin_dependencies_met() ) {
+			return;
+		}
+
+		/**
+		 * Returns the main instance of Sensei_Share_Your_Grade to prevent the need to use globals.
+		 *
+		 * @since  1.0.0
+		 * @return object Sensei_Share_Your_Grade
+		 */
+		function Sensei_Share_Your_Grade() {
+			return Sensei_Share_Your_Grade::instance();
+		} // End Sensei_Share_Your_Grade()
+
+		// Set up the data we will need for our output.
+		add_action( 'sensei_course_results_content_inside_after', array( $instance, 'setup_course_data_before_output' ), 20 );
+		// TODO - change to use more appropriate hooks when available.
+		add_action( 'sensei_lesson_single_meta', array( $instance, 'setup_lesson_data_before_output' ), 20 );
+		add_action( 'sensei_quiz_back_link', array( $instance, 'setup_lesson_data_before_output' ), 4 );
+
+		// Display a message when viewing course results.
+		add_action( 'sensei_course_results_content_inside_after', array( $instance, 'output_sharing_message' ), 30 );
+		// TODO - change to use more appropriate hooks when available.
+		add_action( 'sensei_lesson_single_meta', array( $instance, 'output_sharing_message' ), 30 );
+		add_action( 'sensei_quiz_back_link', array( $instance, 'output_sharing_message' ), 5 );
+
+		// Display sharing buttons when viewing course results.
+		add_action( 'sensei_course_results_content_inside_after', array( $instance, 'output_sharing_buttons' ), 40 );
+		// TODO - change to use more appropriate hooks when available.
+		add_action( 'sensei_lesson_single_meta', array( $instance, 'output_sharing_buttons' ), 30 );
+		add_action( 'sensei_quiz_back_link', array( $instance, 'output_sharing_buttons' ), 5 );
+
+		// Conditionally output the JavaScript for the Google Plus button, if it is present.
+		add_action( 'wp_footer', array( $instance, 'maybe_render_googleplus_js' ) );
+
+		// Load frontend CSS
+		add_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_styles' ), 10 );
+	}
 
 	/**
 	 * Load the plugin's localisation file.
@@ -742,13 +761,14 @@ final class Sensei_Share_Your_Grade {
 	 * @since 1.0.0
 	 * @static
 	 * @see Sensei_Share_Your_Grade()
-	 * @return Main Sensei_Share_Your_Grade instance
+	 * @return Sensei_Share_Your_Grade instance
 	 */
-	public static function instance ( $file, $version = '1.0.2' ) {
-		if ( is_null( self::$_instance ) )
-			self::$_instance = new self( $file, $version );
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
 		return self::$_instance;
-	} // End instance()
+	}
 
 	/**
 	 * Cloning is forbidden.

--- a/sensei-share-your-grade.php
+++ b/sensei-share-your-grade.php
@@ -10,6 +10,7 @@
  *
  * Requires at least: 3.8
  * Tested up to: 4.1
+ * Requires PHP: 5.6
  *
  * Text Domain: sensei-share-your-grade
  * Domain Path: /languages/
@@ -19,26 +20,23 @@
  * @author Matty Cohen
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+define( 'SENSEI_SHARE_YOUR_GRADE_VERSION', '1.0.3' );
+define( 'SENSEI_SHARE_YOUR_GRADE_PLUGIN_FILE', __FILE__ );
+define( 'SENSEI_SHARE_YOUR_GRADE_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 require_once dirname( __FILE__ ) . '/includes/class-sensei-share-your-grade-dependency-checker.php';
 
-if ( ! Sensei_Share_Your_Grade_Dependency_Checker::are_dependencies_met() ) {
+if ( ! Sensei_Share_Your_Grade_Dependency_Checker::are_system_dependencies_met() ) {
 	return;
 }
 
-define( 'SENSEI_SHARE_YOUR_GRADE_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
-
 require_once dirname( __FILE__ ) . '/includes/class-sensei-share-your-grade.php';
 
-Sensei_Share_Your_Grade();
+// Load the plugin after all the other plugins have loaded.
+add_action( 'plugins_loaded', array( 'Sensei_Share_Your_Grade', 'init' ), 5 );
 
-/**
- * Returns the main instance of Sensei_Share_Your_Grade to prevent the need to use globals.
- *
- * @since  1.0.0
- * @return object Sensei_Share_Your_Grade
- */
-function Sensei_Share_Your_Grade() {
-	return Sensei_Share_Your_Grade::instance( __FILE__, '1.0.3' );
-} // End Sensei_Share_Your_Grade()
+Sensei_Share_Your_Grade::instance();


### PR DESCRIPTION
This brings over the work to check dependencies and load plugin after the other plugins have loaded. This simplifies our Sensei check and makes it work for non-standard install locations.

### Testing Instructions
- If activated, deactivate all versions of Sensei. 
- Remove `sensei-version` and `woothemes-sensei-version` options.
- If not active, activate this plugin on built version of this branch. Verify the Sensei dependency message shows on Plugins page and Dashboard page.
- Activate Sensei 1.12.x. Verify message disappears.
- Deactivate Sensei 1.12.x. Activate Sensei 2.x. Verify message is still gone.
- Deactivate Sensei 2.x and activate Sensei with WooCommerce Paid Courses. Verify message is still gone.

Test PHP version:
- Activate Sensei and version of this branch on PHP 5.2-5.5. Verify PHP version notice appears.