### PR TITLE
Update the repo templates titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,28 +9,28 @@ assignees: ''
 
 <!-- Thanks for contributing to Sensei Share Your Grade! Pick a clear title ("Lesson: Show complexity in individual lessons") and proceed. -->
 
-#### Steps to Reproduce
+### Steps to Reproduce
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-#### What I Expected
+### What I Expected
 
 
-#### What Happened Instead
+### What Happened Instead
 
 
-#### PHP / WordPress / Sensei Share Your Grade / Sensei LMS version
+### PHP / WordPress / Sensei Share Your Grade / Sensei LMS version
 
 
-#### Browser / OS version
+### Browser / OS version
 
 
-#### Screenshot / Video
+### Screenshot / Video
 
 
-#### Context / Source
+### Context / Source
 <!-- Optional: share your unique context to help us understand your perspective. -->
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,14 +9,14 @@ assignees: ''
 
 <!-- Thanks for contributing to Sensei Share Your Grade! Pick a clear title ("Lesson: Show complexity in individual lessons") and proceed. -->
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,8 +23,3 @@ Helpful tips for screenshots:
 https://en.support.wordpress.com/make-a-screenshot/
 -->
 ### Screenshot / Video
-
-
-
-<!-- Add the following only if this is meant to be in the changelog -->
-### Proposed changelog entry for your changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,20 @@
 Fixes #
 
-#### Changes proposed in this Pull Request:
+### Changes proposed in this Pull Request
 
 *
 
-#### Testing instructions:
+### Testing instructions
 
 *
 
 <!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
-#### New/Updated Hooks
+### New/Updated Hooks
 
 *
 
 <!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
-#### Deprecated Code
+### Deprecated Code
 
 *
 
@@ -22,9 +22,9 @@ Fixes #
 Helpful tips for screenshots:
 https://en.support.wordpress.com/make-a-screenshot/
 -->
-#### Screenshot / Video
+### Screenshot / Video
 
 
 
 <!-- Add the following only if this is meant to be in the changelog -->
-#### Proposed changelog entry for your changes:
+### Proposed changelog entry for your changes


### PR DESCRIPTION
### Changes proposed in this Pull Request

- Make the main titles in the repo templates bigger. It allows us to create sub-titles with a good readability.
- Also removed some periods to standardize the titles.