### PR TITLE
Bump "tested up to" version

### DIFF
--- a/sensei-share-your-grade.php
+++ b/sensei-share-your-grade.php
@@ -8,9 +8,9 @@
  * Author URI: https://automattic.com/
  * Woo: 435830:700f6f6786c764debcd5dfb789f5f506
  *
- * Requires at least: 4.1
- * Tested up to: 5.4
- * Requires PHP: 5.6
+ * Requires at least: 5.4
+ * Tested up to: 5.6
+ * Requires PHP: 7.0
  *
  * Text Domain: sensei-share-your-grade
  * Domain Path: /languages/


### PR DESCRIPTION
Tested in WP 5.6, and it's working well.

- Bump WP required versions.
- Bump PHP required version.