### PR TITLE
Fix array index issue in PHP 7.4

### DIFF
--- a/includes/class-sensei-share-your-grade.php
+++ b/includes/class-sensei-share-your-grade.php
@@ -472,7 +472,7 @@ final class Sensei_Share_Your_Grade {
 		global $post;
 		if( $this->is_lesson() ) {
 			// If lesson is not passed, leave the message blank so nothing will be output
-			if ( true !== $this->_lesson_data['has_passed'] ) {
+			if ( ! isset( $this->_lesson_data['has_passed'] ) || true !== $this->_lesson_data['has_passed'] ) {
 				$message = '';
 				return $message;
 			}
@@ -548,7 +548,7 @@ final class Sensei_Share_Your_Grade {
 	 */
 	private function _get_status () {
 		$template = 'failed';
-		if ( true == $this->_course_data['has_passed'] ) {
+		if ( isset( $this->_course_data['has_passed'] ) && true == $this->_course_data['has_passed'] ) {
 			$template = 'passed';
 		}
 		elseif ( true == $this->_lesson_data['has_passed'] && 0 < intval($this->_lesson_data['user_grade']) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes an PHP issue that happens in PHP 7.4: `Trying to access array offset on value of type null`

### Testing instructions

* Setup the env with PHP 7.4.
* Create a course with 2 lessons.
* Complete one lesson and leave the other uncompleted.
* Access both lessons and make sure you don't see any error in the `debug.log`.