### PR TITLE
Prepare 2.0.2 with end-of-life notice

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Sensei Share Your Grade Changelog ***
 
-2021.07.26 - version 2.0.2
+2021.07.29 - version 2.0.2
 * Adds notice to warn users that this plugin is no longer maintained.
 
 2020.04.02 - version 2.0.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Sensei Share Your Grade Changelog ***
 
+2021.07.26 - version 2.0.2
+* Adds notice to warn users that this plugin is no longer maintained.
+
 2020.04.02 - version 2.0.1
 * New: Add Hungarian translation - #36
 * Tweak: Remove unnecessary call to `user_started_course` - #41

--- a/includes/class-sensei-share-your-grade.php
+++ b/includes/class-sensei-share-your-grade.php
@@ -121,6 +121,61 @@ final class Sensei_Share_Your_Grade {
 
 		// Load frontend CSS
 		add_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_styles' ), 10 );
+
+		add_action( 'admin_enqueue_scripts', [ $instance, 'enqueue_eol_style' ] );
+		add_action( 'after_plugin_row_' . SENSEI_SHARE_YOUR_GRADE_PLUGIN_BASENAME, [ $instance, 'add_eol_message' ] );
+	}
+
+	/**
+	 * Add the custom styling to hide the box shadow of the plugin row.
+	 */
+	public function enqueue_eol_style() {
+		$screen = get_current_screen();
+
+		if ( ! $screen || ! in_array( $screen->id, [ 'plugins', 'plugins-network' ], true ) ) {
+			return;
+		}
+
+		wp_register_style( 'sensei-share-your-grade-eol-style', false );
+		wp_enqueue_style( 'sensei-share-your-grade-eol-style' );
+		wp_add_inline_style(
+			'sensei-share-your-grade-eol-style',
+			sprintf( '[data-plugin="%1$s"] td, [data-plugin="%1$s"] th { box-shadow: none!important;  }', SENSEI_SHARE_YOUR_GRADE_PLUGIN_BASENAME )
+		);
+	}
+
+	/**
+	 * Adds the end of maintenance message on the plugin listing.
+	 */
+	public function add_eol_message() {
+
+		if ( is_network_admin() ) {
+			$active_class = is_plugin_active_for_network( SENSEI_SHARE_YOUR_GRADE_PLUGIN_BASENAME ) ? ' active' : '';
+		} else {
+			$active_class = is_plugin_active( SENSEI_SHARE_YOUR_GRADE_PLUGIN_BASENAME ) ? ' active' : '';
+		}
+
+		/** @var WP_Plugins_List_Table $wp_list_table */
+		$wp_list_table = _get_list_table(
+			'WP_Plugins_List_Table',
+			array(
+				'screen' => get_current_screen(),
+			)
+		);
+
+		printf(
+			'<tr class="plugin-update-tr%s">' .
+			'<td colspan="%s" class="plugin-update colspanchange">' .
+			'<div class="notice inline notice-warning notice-alt"><p>',
+			$active_class,
+			esc_attr( $wp_list_table->get_column_count() ),
+		);
+
+		echo esc_html__( 'This plugin is no longer being maintained.', 'sensei-share-your-grade' );
+		echo ' <a href="https://senseilms.com/2021/07/21/retiring-two-sensei-lms-extensions/" rel="noreferrer noopener">' . esc_html__( 'More information', 'sensei-share-your-grade' ) . '</a>';
+
+		echo '</p></div></td></tr>';
+
 	}
 
 	/**

--- a/includes/class-sensei-share-your-grade.php
+++ b/includes/class-sensei-share-your-grade.php
@@ -172,7 +172,7 @@ final class Sensei_Share_Your_Grade {
 		);
 
 		echo esc_html__( 'This plugin is no longer being maintained.', 'sensei-share-your-grade' );
-		echo ' <a href="https://senseilms.com/2021/07/21/retiring-two-sensei-lms-extensions/" rel="noreferrer noopener">' . esc_html__( 'More information', 'sensei-share-your-grade' ) . '</a>';
+		echo ' <a href="https://senseilms.com/2021/07/29/retiring-two-sensei-lms-extensions/" rel="noreferrer noopener">' . esc_html__( 'More information', 'sensei-share-your-grade' ) . '</a>';
 
 		echo '</p></div></td></tr>';
 

--- a/languages/sensei-share-your-grade.pot
+++ b/languages/sensei-share-your-grade.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2020 Automattic
+# Copyright (C) 2021 Automattic
 # This file is distributed under the same license as the Sensei Share Your Grade plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sensei Share Your Grade 2.0.1\n"
+"Project-Id-Version: Sensei Share Your Grade 2.0.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sensei-share-your-grade\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-08-26T17:28:23+00:00\n"
+"POT-Creation-Date: 2021-07-22T19:08:20+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: sensei-share-your-grade\n"
@@ -23,7 +23,7 @@ msgid "https://woocommerce.com/products/sensei-share-your-grade/"
 msgstr ""
 
 #. Description of the plugin
-msgid "Let your students strut their stuff (and promote your course) by sharing their progress on social media."
+msgid "Let your students strut their stuff (and promote your course) by sharing their progress on social media. This plugin is no longer maintained."
 msgstr ""
 
 #. Author of the plugin
@@ -53,40 +53,48 @@ msgstr ""
 msgid "<strong>Sensei Share Your Grade</strong> requires that the plugin <strong>Sensei</strong> (minimum version: <strong>%1$s</strong>) is installed and activated."
 msgstr ""
 
-#: includes/class-sensei-share-your-grade.php:292
+#: includes/class-sensei-share-your-grade.php:174
+msgid "This plugin is no longer being maintained."
+msgstr ""
+
+#: includes/class-sensei-share-your-grade.php:175
+msgid "More information"
+msgstr ""
+
+#: includes/class-sensei-share-your-grade.php:347
 msgid "Share your progress!"
 msgstr ""
 
-#: includes/class-sensei-share-your-grade.php:293
+#: includes/class-sensei-share-your-grade.php:348
 msgid "Go on, get social! Share your progress with your friends and family on social media."
 msgstr ""
 
-#: includes/class-sensei-share-your-grade.php:369
+#: includes/class-sensei-share-your-grade.php:424
 msgid "Tweet your Grade"
 msgstr ""
 
-#: includes/class-sensei-share-your-grade.php:510
+#: includes/class-sensei-share-your-grade.php:565
 msgid "I just %%STATUS%% %%POST_NAME%%, over at %%SITE_NAME%%! Take the course, today! %%COURSE_PERMALINK%%"
 msgstr ""
 
-#: includes/class-sensei-share-your-grade.php:520
+#: includes/class-sensei-share-your-grade.php:575
 msgid "I just %%STATUS%% %%POST_NAME%%, over at %%SITE_NAME%% with %%PERCENTAGE%%%! Take the course, today! %%COURSE_PERMALINK%%"
 msgstr ""
 
-#: includes/class-sensei-share-your-grade.php:530
+#: includes/class-sensei-share-your-grade.php:585
 msgid "Cheer me on as I work to pass the %%POST_NAME%% course, over at %%SITE_NAME%%! Take the course with me, today! %%COURSE_PERMALINK%%"
 msgstr ""
 
-#: includes/class-sensei-share-your-grade.php:617
-#: includes/class-sensei-share-your-grade.php:641
+#: includes/class-sensei-share-your-grade.php:672
+#: includes/class-sensei-share-your-grade.php:696
 msgid "passed"
 msgstr ""
 
-#: includes/class-sensei-share-your-grade.php:619
-#: includes/class-sensei-share-your-grade.php:644
+#: includes/class-sensei-share-your-grade.php:674
+#: includes/class-sensei-share-your-grade.php:699
 msgid "failed"
 msgstr ""
 
-#: includes/class-sensei-share-your-grade.php:639
+#: includes/class-sensei-share-your-grade.php:694
 msgid "completed"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-share-your-grade",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-share-your-grade",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Sensei LMS Share Your Grade",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/sensei-share-your-grade.php
+++ b/sensei-share-your-grade.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://woocommerce.com/products/sensei-share-your-grade/
  * Description: Let your students strut their stuff (and promote your course) by sharing their progress on social media. This plugin is no longer maintained.
  * Author: Automattic
- * Version: 2.0.1
+ * Version: 2.0.2
  * Author URI: https://automattic.com/
  * Woo: 435830:700f6f6786c764debcd5dfb789f5f506
  *
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SENSEI_SHARE_YOUR_GRADE_VERSION', '2.0.1' );
+define( 'SENSEI_SHARE_YOUR_GRADE_VERSION', '2.0.2' );
 define( 'SENSEI_SHARE_YOUR_GRADE_PLUGIN_FILE', __FILE__ );
 define( 'SENSEI_SHARE_YOUR_GRADE_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/sensei-share-your-grade.php
+++ b/sensei-share-your-grade.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Sensei Share Your Grade
  * Plugin URI: https://woocommerce.com/products/sensei-share-your-grade/
- * Description: Let your students strut their stuff (and promote your course) by sharing their progress on social media.
+ * Description: Let your students strut their stuff (and promote your course) by sharing their progress on social media. This plugin is no longer maintained.
  * Author: Automattic
  * Version: 2.0.1
  * Author URI: https://automattic.com/


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds notice that the plugin will not longer receive maintenance.
* Also adds it to the end of the plugin description (in case the plugin is not active).

### Testing instructions

* Ensure notice shows up on the plugins page when the plugin is active.